### PR TITLE
mld1/RouterState: Fix still alive thread

### DIFF
--- a/mld/mld1/RouterState.py
+++ b/mld/mld1/RouterState.py
@@ -166,3 +166,5 @@ class RouterState(object):
         """
         for group in self.group_state.values():
             group.remove()
+        self.clear_general_query_timer()
+        self.clear_other_querier_present_timer()


### PR DESCRIPTION
When using the sample of code :

```
import threading
from mld import InterfaceMLD

mld_if = InterfaceMLD(interface_name='enp2s0')

mld_if.enable()
print('%s %s' % (mld_if.interface_name, mld_if.is_enabled()))

try:
    while(True):
        input()
        print(threading.enumerate())
except KeyboardInterrupt:
    mld_if.remove()
    print('%s %s' % (mld_if.interface_name, mld_if.is_enabled()))
```
the program does not leave cleanly on `KeyboardInterrupt` and a second one is required  to kill the remaining thread causing the following error :

```
Exception ignored in: <module 'threading' from '/usr/lib/python3.7/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 1281, in _shutdown
    t.join()
  File "/usr/lib/python3.7/threading.py", line 1032, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.7/threading.py", line 1048, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```
